### PR TITLE
Implements constructing the slug from the built distribution directory.  Lots of build/compilation improvements.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -7,8 +7,6 @@ set -o errexit    # always exit on error
 set -o pipefail   # don't ignore exit codes when piping output
 # unset GIT_DIR     # Avoid GIT_DIR leak from previous build steps
 
-[ "$BUILDPACK_XTRACE" ] && set -o xtrace
-
 ### Constants
 
 ### Configure directories
@@ -18,71 +16,96 @@ CACHE_DIR=${2:-}
 ENV_DIR=${3:-}
 BP_DIR=$(cd "$(dirname "${0:-}")"; cd ..; pwd)
 
+HEROKU_INSTALL_DIR="${BUILD_DIR}/.heroku"
+NODE_INSTALL_DIR="${HEROKU_INSTALL_DIR}/node"
+
+BUILD_START_EPOCH="$(date +%s)"
+
 ### Load dependencies
 
-source "$BP_DIR/lib/output.sh"
-source "$BP_DIR/lib/environment.sh"
-source "$BP_DIR/lib/failure.sh"
-source "$BP_DIR/lib/binaries.sh"
-source "$BP_DIR/lib/json.sh"
-source "$BP_DIR/lib/cache.sh"
-source "$BP_DIR/lib/dependencies.sh"
-source "$BP_DIR/lib/plugin.sh"
+source "${BP_DIR}/lib/output.sh"
+source "${BP_DIR}/lib/environment.sh"
+source "${BP_DIR}/lib/failure.sh"
+source "${BP_DIR}/lib/binaries.sh"
+source "${BP_DIR}/lib/json.sh"
+source "${BP_DIR}/lib/cache.sh"
+source "${BP_DIR}/lib/dependencies.sh"
+source "${BP_DIR}/lib/plugin.sh"
 
-export PATH="$BUILD_DIR/.heroku/node/bin":$PATH
+export PATH="${BUILD_DIR}/.heroku/node/bin":$PATH
 
 LOG_FILE=$(mktemp -t node-build-log.XXXXX)
-echo "" > "$LOG_FILE"
+echo "" > "${LOG_FILE}"
 
 ### Handle errors
 
 handle_failure() {
   header "Build failed"
-  fail_node_install "$LOG_FILE" "$BUILD_DIR"
-  fail_invalid_semver "$LOG_FILE"
-  warn_aws_proxy "$BUILD_DIR"
-  warn_missing_devdeps "$LOG_FILE" "$BUILD_DIR"
-  warn_econnreset "$LOG_FILE"
-  failure_message | output "$LOG_FILE"
+  fail_node_install "${LOG_FILE}" "${BUILD_DIR}"
+  fail_invalid_semver "${LOG_FILE}"
+  warn_aws_proxy "${BUILD_DIR}"
+  warn_missing_devdeps "${LOG_FILE}" "${BUILD_DIR}"
+  warn_econnreset "${LOG_FILE}"
+  failure_message | output "${LOG_FILE}"
 }
 trap 'handle_failure' ERR
 
 
 ### Failures that should be caught immediately
 
-fail_prebuilt "$BUILD_DIR"
-fail_no_nx_workspace "$BUILD_DIR"
-fail_dot_heroku "$BUILD_DIR"
-fail_dot_heroku_node "$BUILD_DIR"
-fail_invalid_package_json "$BUILD_DIR"
-fail_multiple_lockfiles "$BUILD_DIR"
-warn_prebuilt_modules "$BUILD_DIR"
-warn_missing_package_json "$BUILD_DIR"
+fail_prebuilt "${BUILD_DIR}"
+fail_no_nx_workspace "${BUILD_DIR}"
+fail_dot_heroku "${BUILD_DIR}"
+fail_dot_heroku_node "${BUILD_DIR}"
+fail_invalid_package_json "${BUILD_DIR}"
+fail_multiple_lockfiles "${BUILD_DIR}"
+warn_prebuilt_modules "${BUILD_DIR}"
+warn_missing_package_json "${BUILD_DIR}"
 
 ### Compile
 
 create_env() {
-  write_profile "$BP_DIR" "$BUILD_DIR"
-  write_export "$BP_DIR" "$BUILD_DIR"
-  export_env_dir "$ENV_DIR"
+  write_profile "${BP_DIR}" "${BUILD_DIR}"
+  write_export "${BP_DIR}" "${BUILD_DIR}"
+  export_env_dir "${ENV_DIR}"
   create_default_env
 }
 
-header "Creating runtime environment" | output "$LOG_FILE"
+header "Creating runtime environment" | output "${LOG_FILE}"
 
-mkdir -p "$BUILD_DIR/.heroku/node/"
-cd "$BUILD_DIR"
+mkdir -p "${NODE_INSTALL_DIR}"
+cd "${BUILD_DIR}"
+
 # can't pipe the whole thing because piping causes subshells, preventing exports
 create_env
-list_node_config | output "$LOG_FILE"
+list_node_config | output "${LOG_FILE}"
 create_build_env
+
+bool_var() {
+  case "${!1}" in
+    true)
+      return 0
+      ;;
+    false)
+      return 1
+      ;;
+    *)
+      echo "parameter: ${1}='${!1}' is not a boolean, expected 'true' or 'false'" >&2
+      return 1
+      ;;
+  esac
+}
+
+if bool_var BUILDPACK_XTRACE; then
+  set -o xtrace
+fi
 
 install_bins() {
   local node_engine npm_engine yarn_engine npm_version node_version
 
-  node_engine=$(read_json "$BUILD_DIR/package.json" ".engines.node")
-  npm_engine=$(read_json "$BUILD_DIR/package.json" ".engines.npm")
-  pnpm_engine=$(read_json "$BUILD_DIR/package.json" ".engines.pnpm")
+  node_engine=$(read_json "${BUILD_DIR}/package.json" ".engines.node")
+  npm_engine=$(read_json "${BUILD_DIR}/package.json" ".engines.npm")
+  pnpm_engine=$(read_json "${BUILD_DIR}/package.json" ".engines.pnpm")
 
   echo "engines.node (package.json):  ${node_engine:-unspecified}"
   echo "engines.npm (package.json):   ${npm_engine:-unspecified (use default)}"
@@ -91,14 +114,23 @@ install_bins() {
 
   warn_node_engine "$node_engine"
 
-  install_nodejs "$node_engine" "$BUILD_DIR/.heroku/node"
-  install_npm "$npm_engine" "$BUILD_DIR/.heroku/node"
+  install_nodejs "$node_engine" "${NODE_INSTALL_DIR}"
+  install_npm "$npm_engine" "${NODE_INSTALL_DIR}"
   install_pnpm "$pnpm_engine"
   install_nx
+  install_jq
 }
 
-header "Installing binaries" | output "$LOG_FILE"
-install_bins | output "$LOG_FILE"
+header "Installing binaries" | output "${LOG_FILE}"
+install_bins | output "${LOG_FILE}"
+
+header "Configuring XDG environment to utilize cache, notably for pnpm" | output "${LOG_FILE}"
+(
+  export XDG_DATA_HOME="${CACHE_DIR}"
+  printf "  \u2713  Set XDG_DATA_HOME to ${CACHE_DIR}\n"
+  export XDG_CACHE_HOME="${CACHE_DIR}"
+  printf "  \u2713  Set XDG_CACHE_HOME to ${CACHE_DIR}\n"
+) | output "${LOG_FILE}"
 
 restore_cache() {
   local cache_status="$(get_cache_status "$CACHE_DIR")"
@@ -108,10 +140,10 @@ restore_cache() {
     echo "Caching has been disabled because NODE_MODULES_CACHE=${NODE_MODULES_CACHE}"
   elif [[ "$cache_status" == "valid" ]]; then
     header "Restoring cache"
-    restore_default_cache_directories "$BUILD_DIR" "$CACHE_DIR"
+    restore_default_cache_directories "${BUILD_DIR}" "$CACHE_DIR"
   elif [[ "$cache_status" == "new-signature" ]]; then
     header "Restoring cache"
-    echo "Cached directories were not restored due to a change in version of node, npm, yarn or stack"
+    echo "Cached directories were not restored due to a change in version of node, npm, pnpm or stack"
     echo "Module installation may take longer for this build"
   else
     # No cache exists, be silent
@@ -119,58 +151,105 @@ restore_cache() {
   fi
 }
 
-restore_cache | output "$LOG_FILE"
+restore_cache | output "${LOG_FILE}"
 
-build_dependencies() {
-  local cache_status start
-  pnpm_node_modules "$BUILD_DIR"
+build_appliance() {
   (
-    cd "$BUILD_DIR" || return
-    set -f
-    filter=( "*" )
-    for app in ${APPLIANCE_NX_PROJECTS}; do
-        filter+=( '!'"${app}" )
-    done;
-    IFS=","
-    echo "${filter[*]}"
-    nx run-many -t build --exclude="${filter[*]}"
+    cd "${BUILD_DIR}" || return
+    echo "Appliance project dependencies: ${APPLIANCE_NX_PROJECTS}"
+    nx run-many -t build -p ${APPLIANCE_NX_PROJECTS}
   )
 }
 
-header "Installing dependencies" | output "$LOG_FILE"
-build_dependencies | output "$LOG_FILE"
+header "Installing dependencies" | output "${LOG_FILE}"
+pnpm_node_modules "${BUILD_DIR}" | output "${LOG_FILE}"
+
+header "Building appliance"
+build_appliance | output "${LOG_FILE}"
 
 cache_build() {
   clear_cache "$CACHE_DIR"
-  if ! ${NODE_MODULES_CACHE:-true}; then
+  if ! ${NODE_MODULES_CACHE:-false}; then
     # we've already warned that caching is disabled in the restore step
     # so be silent here
     :
   else
     header "Caching build"
-    save_default_cache_directories "$BUILD_DIR" "$CACHE_DIR"
+    save_default_cache_directories "${BUILD_DIR}" "$CACHE_DIR"
   fi
   save_signature "$CACHE_DIR"
 }
 
-prune_devdependencies() {
-  pnpm_prune_devdependencies "$BUILD_DIR"
+cache_build | output "${LOG_FILE}"
+
+DIST_DIR="${BUILD_DIR}/dist"
+
+prepare_distribution() {
+  echo " -- Configuring pnpm workspace"
+  echo -e "packages:\n  - apps/*" > "${DIST_DIR}/pnpm-workspace.yaml"
+  printf "    \u2713  pnpm-workspace.yaml created\n"
+
+  (
+    (
+      cat "${BUILD_DIR}/package.json" |
+        jq '{ name: "dist", version: "0.0.1", pnpm: { overrides: .pnpm.overrides } }' > "${DIST_DIR}/package.json"
+    ) || fail
+  ) | indent
+  printf "    \u2713  distribution package.json created with overrides from root file\n"
+
+  mv "${BUILD_DIR}/.npmrc" "${DIST_DIR}"
+  echo "node-linker=hoisted" >> "${DIST_DIR}/.npmrc"
+  printf "    \u2713  npmrc file created from root file with node-linker=hoisted appended\n"
+
+  echo " -- Constructing distribution"
+
+  pnpm -C "${DIST_DIR}" install | indent
+  printf "    \u2713  link appliance modules\n"
+
+  mv "${PROCFILE}" "${DIST_DIR}"
+  printf "    \u2713  move appliance procfile\n"
+
+  mv "${BUILD_DIR}/.profile.d" "${DIST_DIR}"
+  printf "    \u2713  move profile scripts\n"
+
+  mv "${HEROKU_INSTALL_DIR}" "${DIST_DIR}"
+  printf "    \u2713  move dyno binaries\n"
 }
 
-cache_build | output "$LOG_FILE"
-header "Pruning devDependencies" | output "$LOG_FILE"
-prune_devdependencies | output "$LOG_FILE"
+replace_build() {
+  rsync $(bool_var BUILDPACK_DEBUG && echo "-v") \
+        --archive \
+        --inplace \
+        --copy-dirlinks \
+        --delete-after \
+        --whole-file \
+        --no-compress \
+        --link-dest "${DIST_DIR}/" "${DIST_DIR}/" "${BUILD_DIR}" \
+    || fail
+}
+
+header "Preparing distribution" | output "${LOG_FILE}"
+prepare_distribution | output "${LOG_FILE}"
+
+header "Replace build with distribution" | output "${LOG_FILE}"
+replace_build | output "${LOG_FILE}"
+
+install_plugin "${BP_DIR}" "${BUILD_DIR}"
+
+header "Build succeeded!" | output "${LOG_FILE}"
+
+BUILD_END_EPOCH="$(date +%s)"
 
 summarize_build() {
+  # Note that this works only because buildpacks timeout after 15 minutes, so we know we don't need to deal with
+  # greater time spans.
+  echo "  Build Time: $(date +%Mm%Ss -d "1970-01-01 + ${BUILD_END_EPOCH} seconds - ${BUILD_START_EPOCH} seconds")"
   if $NODE_VERBOSE; then
-    list_dependencies "$BUILD_DIR"
+    list_dependencies "${BUILD_DIR}"
   fi
 }
 
-install_plugin "$BP_DIR" "$BUILD_DIR"
+summarize_build | output "${LOG_FILE}"
 
-header "Build succeeded!" | output "$LOG_FILE"
-summarize_build | output "$LOG_FILE"
-
-warn_no_start "$BUILD_DIR"
-warn_unmet_dep "$LOG_FILE"
+warn_no_start "${BUILD_DIR}"
+warn_unmet_dep "${LOG_FILE}"

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -67,8 +67,6 @@ install_nodejs() {
   chmod +x "$dir"/bin/*
 }
 
-printenv
-
 install_npm() {
   local npm_version
   local version="$1"
@@ -107,4 +105,14 @@ install_nx() {
   # Verify nx works before capturing and ensure its stderr is inspectable later.
   nx --version 2>&1 1>/dev/null
   echo "nx $(nx --version) installed"
+}
+
+install_jq() {
+  # jq is available by default, but lets handle in case this changes.
+  if ! which jq >/dev/null; then
+    apt-get install jq | indent
+  fi
+  # Verify jq works before capturing and ensure its stderr is inspectable later.
+  jq --version 2>&1 1>/dev/null
+  echo "jq $(jq --version) installed"
 }

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -1,30 +1,30 @@
 #!/usr/bin/env bash
 
 create_signature() {
-  echo "v2; ${STACK}; $(node --version); $(npm --version); $(yarn --version 2>/dev/null || true); ${PREBUILD}"
+  echo "v2; ${STACK}; $(node --version); $(npm --version); $(pnpm --version)"
 }
 
 save_signature() {
-  local cache_dir="$1"
-  create_signature > "$cache_dir/node/signature"
+  local -r cache_dir="${1}"
+  create_signature > "${cache_dir}/node/signature"
 }
 
 load_signature() {
-  local cache_dir="$1"
-  if test -f "$cache_dir/node/signature"; then
-    cat "$cache_dir/node/signature"
+  local -r cache_dir="${1}"
+  if test -f "${cache_dir}/node/signature"; then
+    cat "${cache_dir}/node/signature"
   else
     echo ""
   fi
 }
 
 get_cache_status() {
-  local cache_dir="$1"
+  local -r cache_dir="${1}"
   if ! ${NODE_MODULES_CACHE:-true}; then
     echo "disabled"
-  elif ! test -d "$cache_dir/node/"; then
+  elif ! test -d "${cache_dir}/node/"; then
     echo "not-found"
-  elif [ "$(create_signature)" != "$(load_signature "$cache_dir")" ]; then
+  elif [ "$(create_signature)" != "$(load_signature "${cache_dir}")" ]; then
     echo "new-signature"
   else
     echo "valid"
@@ -32,35 +32,34 @@ get_cache_status() {
 }
 
 restore_default_cache_directories() {
-  local build_dir=${1:-}
-  local cache_dir=${2:-}
+  local -r build_dir="${1:-}"
+  local -r cache_dir="${2:-}"
 
   # node_modules
-  if [[ -e "$cache_dir/node/cache/node_modules" ]]; then
+  if [[ -e "${cache_dir}/node/cache/node_modules" ]]; then
     echo "- node_modules"
-    mkdir -p "$(dirname "$build_dir/node_modules")"
-    mv "$cache_dir/node/cache/node_modules" "$build_dir/node_modules"
+    mkdir -p "$(dirname "${build_dir}/node_modules")"
+    mv "${cache_dir}/node/cache/node_modules" "${build_dir}/node_modules"
   else
     echo "- node_modules (not cached - skipping)"
   fi
 }
 
 clear_cache() {
-  local cache_dir="$1"
-  rm -rf "$cache_dir/node"
-  mkdir -p "$cache_dir/node"
-  mkdir -p "$cache_dir/node/cache"
+  local -r cache_dir="${1}"
+  rm -rf "${cache_dir}/node"
+  mkdir -p "${cache_dir}/node/cache"
 }
 
 save_default_cache_directories() {
-  local build_dir=${1:-}
-  local cache_dir=${2:-}
+  local -r build_dir="${1:-}"
+  local -r cache_dir="${2:-}"
 
   # node_modules
-  if [[ -e "$build_dir/node_modules" ]]; then
+  if [[ -e "${build_dir}/node_modules" ]]; then
     echo "- node_modules"
-    mkdir -p "$cache_dir/node/cache/node_modules"
-    cp -a "$build_dir/node_modules" "$(dirname "$cache_dir/node/cache/node_modules")"
+    mkdir -p "${cache_dir}/node/cache/node_modules"
+    cp -al "${build_dir}/node_modules" "${cache_dir}/node/cache/node_modules"
   else
     # this can happen if there are no dependencies
     echo "- node_modules (nothing to cache)"

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -1,23 +1,36 @@
 #!/usr/bin/env bash
 
+source "$BP_DIR/lib/failure.sh"
+
 list_dependencies() {
-  local build_dir="$1"
-  cd "$build_dir" || return
+  local -r build_dir="$1"
+  cd "$build_dir" || fail
   (pnpm ls --depth=0 | tail -n +2 || true) 2>/dev/null
 }
 
 pnpm_node_modules() {
-  local build_dir=${1:-}
+  local -r build_dir=${1:-}
   if [ -e "$build_dir/package.json" ]; then
-    cd "$build_dir" || return
-    NODE_ENV= pnpm install 2>&1
+    cd "$build_dir" || fail
+    # N.B. the echo is to send an enter to pnpm install. This files an edge that can cause builds to fail
+    # if we drastically modify how we utilize pnpm in the build process, possibly also in our repo. Under certain
+    # changes, a wholesale rebuild of node_modules is triggered, resulting in the following prompt:
+    #
+    # The modules directory at "..." will be removed and reinstalled from scratch. Proceed? (Y/n) ‣ true
+    echo | NODE_ENV= pnpm install --frozen-lockfile 2>&1
   else
     echo "Skipping (no package.json)"
   fi
-}
 
-pnpm_prune_devdependencies() {
-  local build_dir=${1:-}
-  cd "$build_dir" || return
-  pnpm prune 2>&1
+#   # Workaround pnpm metadata issue where it's not always installed and can only be
+#   # forced via pnpm update. This will ensure the metadata cache is built without modifying
+#   # our checked in package.json.
+#   local -r temp_dir=$(mktemp -d) || fail
+#   echo "-- Applying pnpm offline metadata workaround in temp directory: ${temp_dir}"
+#   cp "${build_dir}/package.json" "${temp_dir}"
+#   printf "    \u2713  root package.json copied: ${temp_dir}\n"
+#   pnpm -C "${temp_dir}" update --lockfile-only > /dev/null
+#   printf "    \u2713  executed pnpm update --lockfile-only to generate offline metadata\n"
+#   rm -rf "${temp_dir}"
+#   printf "    \u2713  temp directory cleaned up\n"
 }

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -51,13 +51,13 @@ list_node_config() {
 export_env_dir() {
   local env_dir=$1
   if [ -d "$env_dir" ]; then
-    local whitelist_regex=${2:-''}
-    local blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH|LANG|BUILD_DIR)$'}
+    local allowlist_regex=${2:-''}
+    local denylist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH|LANG|BUILD_DIR)$'}
     # shellcheck disable=SC2164
     pushd "$env_dir" >/dev/null
     for e in *; do
       [ -e "$e" ] || continue
-      echo "$e" | grep -E "$whitelist_regex" | grep -qvE "$blacklist_regex" &&
+      echo "$e" | grep -E "$allowlist_regex" | grep -qvE "$denylist_regex" &&
       export "$e=$(cat "$e")"
       :
     done

--- a/lib/output.sh
+++ b/lib/output.sh
@@ -7,6 +7,10 @@ info() {
   echo "       $*" || true
 }
 
+indent() {
+    sed -u 's/^/    /'
+}
+
 # format output and send a copy to the log
 output() {
   local logfile="$1"


### PR DESCRIPTION

    Implements constructing the slug from the built distribution directory.
    
    Lots of build/compilation improvements.
    
    Folds multi-procfile support into our buildpack. It was super easy to fold in,
    had to essentially be done anyway and simplifies our Heroku App setup.
    
    Changes default for NODE_MODULES_CACHE to false as this is actually worse
    performance for pnpm when hard linking from the cached store.
    
    Places pnpm's cached store on heroku's CACHE_DIR.
    
    Updates much of the style from heroku's style to our/my style for shell scripts,
    notably always employing brace enclosure around variables and double quoting
    (unless double quoting would change behavior, e.g. when for looping over a variable
    of IFS separated values).
    
    Adds build timing to build summary.

    Combined improvements reduce web-appliance slug from ~255-315MB -> 156MB. Build times are  
    reduced from ~5m to ~1m.

    Fixes missed update to use APPLIANCE_NX_PROJECTS from previous commit: feca3a8c95f83e643

